### PR TITLE
F #7 enable configuration of the verification role from external invokation

### DIFF
--- a/playbooks/verification.yml
+++ b/playbooks/verification.yml
@@ -1,16 +1,12 @@
 ---
+
 # Will launch verification framework on the frontends
 - hosts: "{{ frontend_group | d('frontend') }}"
   roles:
     - role: verification
-      vars:
-        run_core_services_verification: false
-        run_network_benchmark: false
           
 # Run network tests on the hypervisor hosts
 - hosts: "{{ node_group | d('node') }}"
   roles:
     - role: verification
-      vars:
-        run_core_services_verification: false
-        run_network_benchmark: true 
+

--- a/roles/verification/defaults/main.yml
+++ b/roles/verification/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+#################### TEST EXECUTION CONTROL VARIABLES ####################
+run_core_services_verification: false
+run_network_benchmark: false
+
+
+#################### TEST CONFIGURATION VARIABLES ####################
 # Do we want check connection to the test VM? network might be blocked from FE
 test_vm_check_connection: false
 

--- a/roles/verification/defaults/main.yml
+++ b/roles/verification/defaults/main.yml
@@ -26,6 +26,8 @@ test_gw: '10.0.0.1'
 
 # Marketplace App name for test VM instantiation
 test_vm_name: 'Alpine Linux 3.21'
+test_vm_template_extra: |
+  MEMORY="512"
 
 # PArameters for iperf network benchmarking
 iperf:

--- a/roles/verification/tasks/core_services_verification.yml
+++ b/roles/verification/tasks/core_services_verification.yml
@@ -335,6 +335,17 @@
     vm_template_id: "{{ new_vm_template_id if not new_vm_template_id.skipped|default(false) else existing_vm_template_id }}"
   failed_when: new_vm_template_id.skipped|default(false) and existing_vm_template_id.skipped|default(false)
 
+- name: Write extra template variables to a temporary file on the remote host
+  ansible.builtin.copy:
+    content: "{{ test_vm_template_extra }}"
+    dest: "/tmp/test_vm_template_extra.txt"
+
+- name: Update VM template with extra data
+  ansible.builtin.shell: >
+    onetemplate update --append {{ vm_template_id.stdout }} /tmp/test_vm_template_extra.txt
+  register: update_vm_template_extra
+  failed_when: update_vm_template_extra.rc != 0
+
 - name: Get VM template as JSON
   ansible.builtin.shell: >
     onetemplate show {{ vm_template_id.stdout }} -j


### PR DESCRIPTION
**Description**
To enable configuration of the verification role from external invokation, and facilitate easy reuse in other repos:
 - Adapt the verification role to be able to overwrite the role's values by moving from "vars" to "defaults"
 - VM template data can be extended, which has various use cases (in my scenario I needed to specify a scheduling requirement)

With this change an example application of how other repos can build on this one:
https://github.com/OpenNebula/opennebula-hosted-ionos/blob/master/README.md 
