### PR TITLE
B #16 and F#15: remove one-deploy dependency and fix default parameter handling

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -1,6 +1,0 @@
----
-exclude_paths:
-  - vendor/
-
-skip_list:
-  - name[play]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "vendor/ceph-ansible"]
-	path = vendor/ceph-ansible
-	url = https://github.com/ceph/ceph-ansible.git
-	branch = stable-9.0

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ SHELL := $(shell which bash)
 SELF  := $(patsubst %/,%,$(dir $(abspath $(firstword $(MAKEFILE_LIST)))))
 
 ENV_RUN      = hatch env run -e $(1) --
-ENV_DEFAULT := $(shell hatch env find default)
-ENV_CEPH    := $(shell hatch env find ceph)
+ENV_ONE_DEPLOY_VALIDATION := $(shell hatch env find validation-default)
 
 I         ?= $(SELF)/inventory/example.yml
 INVENTORY ?= $(I)
@@ -17,56 +16,23 @@ SKIP_TAGS ?= $(S)
 V       ?= vv
 VERBOSE ?= $(V)
 
-ONE_DEPLOY_URL ?= git+https://github.com/OpenNebula/one-deploy.git,master
-
 export
 
 # Make sure we source ANSIBLE_ settings from ansible.cfg exclusively.
 unexport $(filter ANSIBLE_%,$(.VARIABLES))
 
-.PHONY: all
+.PHONY: verification
 
-all: main
+verification: _TAGS      := $(if $(TAGS),-t $(TAGS),)
+verification: _SKIP_TAGS := $(if $(SKIP_TAGS),--skip-tags $(SKIP_TAGS),)
+verification: _VERBOSE   := $(if $(VERBOSE),-$(VERBOSE),)
 
-.PHONY: infra pre ceph site main verification
-
-infra pre ceph site main verification: _TAGS      := $(if $(TAGS),-t $(TAGS),)
-infra pre ceph site main verification: _SKIP_TAGS := $(if $(SKIP_TAGS),--skip-tags $(SKIP_TAGS),)
-infra pre ceph site main verification: _VERBOSE   := $(if $(VERBOSE),-$(VERBOSE),)
-infra pre ceph site main verification: _ASK_VAULT := $(if $(findstring $$ANSIBLE_VAULT;,$(file < $(INVENTORY))),--ask-vault-pass,)
-
-ifdef ENV_DEFAULT
-$(ENV_DEFAULT):
-	hatch env create default
+ifdef ENV_ONE_DEPLOY_VALIDATION
+$(ENV_ONE_DEPLOY_VALIDATION):
+	hatch env create validation-default
 endif
 
-infra pre site main verification: $(ENV_DEFAULT)
+verification: $(ENV_ONE_DEPLOY_VALIDATION)
 	cd $(SELF)/ && \
-	$(call ENV_RUN,default) ansible-playbook $(_VERBOSE) -i $(INVENTORY) $(_ASK_VAULT) $(_TAGS) $(_SKIP_TAGS) $(SELF)/playbooks/$@.yml
+	$(call ENV_RUN,validation-default) ansible-playbook $(_VERBOSE) -i $(INVENTORY) $(_TAGS) $(_SKIP_TAGS) $(SELF)/playbooks/verification.yml
 
-ifdef ENV_CEPH
-$(ENV_CEPH):
-	hatch env create ceph
-endif
-
-ceph: $(ENV_CEPH)
-	cd $(SELF)/ && \
-	$(call ENV_RUN,ceph) ansible-playbook $(_VERBOSE) -i $(INVENTORY) $(_ASK_VAULT) $(_TAGS) $(_SKIP_TAGS) $(SELF)/playbooks/$@.yml
-
-.PHONY: requirements requirements-hatch requirements-galaxy clean-requirements
-
-requirements: requirements-hatch requirements-galaxy
-
-requirements-hatch: $(SELF)/pyproject.toml $(ENV_DEFAULT)
-
-requirements-galaxy: $(ENV_DEFAULT)
-	$(call ENV_RUN,default) ansible-galaxy collection install --upgrade $(ONE_DEPLOY_URL)
-
-clean-requirements:
-	$(if $(ENV_DEFAULT),hatch env remove default,)
-	$(if $(ENV_CEPH),hatch env remove ceph,)
-
-.PHONY: lint-ansible
-
-lint-ansible: $(ENV_DEFAULT)
-	cd $(SELF)/ && $(call ENV_RUN,default) ansible-lint roles/ playbooks/

--- a/README.md
+++ b/README.md
@@ -2,20 +2,11 @@
 
 # one-deploy-validation
 
-## Checkout
-
-1. Resursively clone the `engineering-deploy` repository
-
-   ```shell
-   cd ~/ && git clone --recursive git@github.com:OpenNebula/one-deploy-validation.git
-   ```
+This repository provides a toolset for automating the validation of an OpenNebula deployment.
 
 ## Requirements
 
-> [!NOTE]
-> If Makefile is used then it will create python virtual environments using `hatch` (on demand).
-
-1. Install `hatch`
+1. Install `hatch`, which is used by the [Makefile](./Makefile) to manage virtual environments.
 
    ```shell
    pip install hatch
@@ -27,61 +18,26 @@
    pipx install hatch
    ```
 
-   or use any other method you see fit
-
-2. Install the `opennebula.deploy` collection with dependencies
-
-   ```shell
-   make requirements
-   ```
-
-   if you'd like to pick specific branch (instead of `master`), tag or a custom fork
-
-   ```shell
-   make requirements ONE_DEPLOY_URL:=git+https://github.com/OpenNebula/one-deploy.git,release-1.2.1
-   ```
-
-   the `one-deploy` repository checkout should be available in `~/.ansible/collections/ansible_collections/opennebula/deploy/`
-
-3. (OPTIONAL) Update the `vendor/ceph-ansible` submodule (if you want to deploy Ceph clusters)
-
-   ```shell
-   cd ~/ && git submodule update --init --recursive -- ./
-   ```
+   or use any other method you see fit.
 
 ## Playbooks/Roles
 
-1. You can create new playbooks and roles as you desire and still reuse the code from `one-deploy`
-
-   ```yaml
-   ---
-   - ansible.builtin.import_playbook: opennebula.deploy.site
-
-   - hosts:
-       - "{{ frontend_group | d('frontend') }}"
-       - "{{ node_group | d('node') }}"
-     roles:
-       - role: { opennebula.deploy.helper.facts, _force: true }
-       - role: example
-   ```
+The development of the tests should be structured in [playbooks](./playbooks/) and [roles](./roles/) directories, following Ansible.
 
 ## Inventory/Execution
 
-> [!NOTE]
-> It's exactly the same as with `one-deploy`.
+1. Inventories are kept in the [inventory](./inventory/) directory, please take a look at [example.yml](./inventory/example.yml)
 
-1. Inventories are kept in the `./inventory/` directory, please take a look at [example.yml](./inventory/example.yml)
-
-2. To execute `ansible-playbook` you can run
+1. To execute `ansible-playbook` you can run
 
    ```shell
-   make I=inventory/example.yml main
+   make I=inventory/example.yml verification
    ```
 
-   all the normal targets are available by default
+## Verification Results
 
-   - [ceph](./playbooks/ceph.yml)
-   - [infra](./playbooks/infra.yml)
-   - [main](./playbooks/main.yml)
-   - [pre](./playbooks/pre.yml)
-   - [site](./playbooks/site.yml)
+The execution of the all the tests produces the following output files on the Ansible controller (e.g. laptop):
+
+- `/tmp/cloud_verification_report.html`
+- `/tmp/conn-matrix-report.html`
+- `/tmp/conn-matrix-raw-data.json`

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,10 +1,5 @@
 [defaults]
-action_plugins    = ./vendor/ceph-ansible/plugins/actions/
-callback_plugins  = ./vendor/ceph-ansible/plugins/callback/
-filter_plugins    = ./vendor/ceph-ansible/plugins/filter/
-roles_path        = ./roles/:./vendor/ceph-ansible/roles/
-library           = ./vendor/ceph-ansible/library/
-module_utils      = ./vendor/ceph-ansible/module_utils/
+roles_path        = ./roles/
 
 inventory             = ./inventory/example.yml
 gathering             = explicit

--- a/inventory/group_vars/ceph.yml
+++ b/inventory/group_vars/ceph.yml
@@ -1,5 +1,0 @@
----
-ceph_origin: distro
-ceph_stable_release: squid
-configure_firewall: false
-no_log_on_ceph_key_tasks: false

--- a/inventory/local-test.yaml
+++ b/inventory/local-test.yaml
@@ -1,0 +1,24 @@
+---
+all:
+  vars:
+    ansible_user: root
+    ensure_keys_for: [root]
+
+    test_vnet_name: public
+    conn_matrix_bridge_name: br0
+    conn_matrix_vnet_name: public
+
+    execute_storage_benchmarking: false
+    verification_check_fireedge_ui: false
+
+    one_version: '7.0'
+
+frontend:
+  hosts:
+    fe: { ansible_host: 172.20.0.3 }
+
+node:
+  hosts:
+    h1: { ansible_host: 172.20.0.4 }
+    h2: { ansible_host: 172.20.0.5 }
+    # h3: { ansible_host: 172.20.0.6 }

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -1,2 +1,0 @@
----
-- ansible.builtin.import_playbook: opennebula.deploy.ceph

--- a/playbooks/conn-matrix.yml
+++ b/playbooks/conn-matrix.yml
@@ -58,26 +58,52 @@
           register: host_ids_and_names
           changed_when: false
 
-        - name: Display host ID mapping to hostnames
-          debug:
-            msg: "Found OpenNebula hosts with IDs: {{ host_ids_and_names.stdout_lines }}"
+        - name: Get list of OpenNebula host to "hostname_cmd" mapping
+          shell: onehost list -j
+          register: host_list_json
+          changed_when: false
+          no_log: true
+
+        - name: Set fact with host to "hostname_cmd" mapping
+          set_fact:
+            host_name_to_hostname_cmd: >-
+                {{
+                  dict(
+                    (host_list_json.stdout | from_json).HOST_POOL.HOST
+                    | map(attribute='NAME')
+                    | zip(
+                        (host_list_json.stdout | from_json).HOST_POOL.HOST
+                        | map(attribute='TEMPLATE')
+                        | map(attribute='HOSTNAME')
+                      )
+                  )
+                }}
 
         - name: Create a dedicated VM group and VM for each host
           ansible.builtin.include_tasks: tasks/conn_matrix_per_host.yml
           loop: "{{ host_ids_and_names.stdout_lines }}"
 
-        - name: Get VM host_name to VM IP mapping
+        - name: Get VM host to VM IP mapping
           shell: onevm list -l HOST,IP --csv --no-header
           register: vm_host_ip_lines
           changed_when: false
 
-        - name: Extract host_name to VM IP mapping
+        - name: Extract host to VM IP mapping
           set_fact:
             host_name_to_vm_ip: >-
-              {{ dict(
-                vm_host_ip_lines.stdout_lines | 
-                map('split', ',') | list
-              ) }}
+              {{
+                dict(
+                  vm_host_ip_lines.stdout_lines
+                  | map('split', ',')
+                  | map('first')
+                  | map('extract', host_name_to_hostname_cmd)
+                  | zip(
+                      vm_host_ip_lines.stdout_lines
+                      | map('split', ',')
+                      | map('last')
+                    )
+                )
+              }}
 
 - hosts: "{{ node_group | d('node') }}"
   gather_facts: false

--- a/playbooks/conn-matrix.yml
+++ b/playbooks/conn-matrix.yml
@@ -1,8 +1,4 @@
 ---
-- hosts: all
-  vars_files:
-    - vars/defaults.yml
-
 - hosts: "{{ node_group | d('node') }}"
   gather_facts: true
   tasks:
@@ -21,6 +17,14 @@
       ansible.builtin.set_fact:
         conn_matrix_pubkey: "{{ conn_matrix_pubkey_raw['content'] | b64decode }}"
 
+    - name: Save the output of the hostname command to the hostname variable
+      ansible.builtin.shell: hostname
+      register: hostname_cmd
+
+    - name: Set fact with hostname
+      ansible.builtin.set_fact:
+        hostname_cmd: "{{ hostname_cmd.stdout }}"
+
 - name: Collect all public keys into a dictionary
   hosts: localhost
   gather_facts: false
@@ -33,7 +37,7 @@
                 hostvars
                 | dict2items
                 | selectattr('value.conn_matrix_pubkey', 'defined')
-                | map(attribute='value.ansible_host')
+                | map(attribute='value.hostname_cmd')
                 | zip(
                     hostvars
                     | dict2items
@@ -43,7 +47,6 @@
               )
             }}
       no_log: true
-
 
 - hosts: "{{ frontend_group | d('frontend') }}"
   tasks:
@@ -91,7 +94,7 @@
         host_name_to_vm_ip: "{{ hostvars[groups[frontend_group | d('frontend')][0]]['host_name_to_vm_ip'] }}"
       when: hostvars[groups[frontend_group | d('frontend')][0]]['host_name_to_vm_ip'] is defined
 
-    - name: Add VM IP+offset/32 to {{ conn_matrix_bridge_name }} and route for each VM IP
+    - name: Add VM IP+offset/32 to {{ _conn_matrix_bridge_name }} and route for each VM IP
       vars:
         _mapping_length: "{{ host_name_to_vm_ip | length }}"
       register: add_vm_ip_route
@@ -100,8 +103,8 @@
                     and ('File exists' not in add_vm_ip_route.stderr or add_vm_ip_route.rc != 2)"
       changed_when: add_vm_ip_route.rc == 0
       ansible.builtin.shell: |
-        ip addr add {{ host_name_to_vm_ip[ansible_host] | ansible.utils.ipmath(_mapping_length) }}/32 dev {{ conn_matrix_bridge_name }}
-        ip route add {{ host_name_to_vm_ip[ansible_host] }}/32 dev {{ conn_matrix_bridge_name }}
+        ip addr add {{ host_name_to_vm_ip[hostname_cmd] | ansible.utils.ipmath(_mapping_length) }}/32 dev {{ _conn_matrix_bridge_name }}
+        ip route add {{ host_name_to_vm_ip[hostname_cmd] }}/32 dev {{ _conn_matrix_bridge_name }}
 
     - name: Ensure results directory exists for this host
       file:
@@ -111,15 +114,15 @@
 
     - name: Test connectivity from this host to all other VMs
       vars:
-        _my_vm_ip: "{{ host_name_to_vm_ip[ansible_host] }}"
-        _other_hostname: "{{ groups[node_group | d('node')] | map('extract', hostvars) | selectattr('ansible_host', 'equalto', other_vm.key) | map(attribute='inventory_hostname') | list | first}}"
+        _my_vm_ip: "{{ host_name_to_vm_ip[hostname_cmd] }}"
+        _other_hostname: "{{ groups[node_group | d('node')] | map('extract', hostvars) | selectattr('hostname_cmd', 'equalto', other_vm.key) | map(attribute='inventory_hostname') | list | first}}"
       loop: "{{ host_name_to_vm_ip | dict2items }}"
       loop_control:
         loop_var: other_vm
       when: other_vm.value != _my_vm_ip
       ansible.builtin.shell: |
         ssh -i ~/.ssh/conn-matrix -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{{ _my_vm_ip }} -- \
-          ping -c {{ conn_matrix_ping_count }} {{ other_vm.value }} | jc --ping > /tmp/conn-matrix-results/{{ inventory_hostname }}/{{ _other_hostname }}.json
+          ping -c {{ _conn_matrix_ping_count }} {{ other_vm.value }} | jc --ping > /tmp/conn-matrix-results/{{ inventory_hostname }}/{{ _other_hostname }}.json
       register: conn_test_result
       retries: 3
       delay: 5
@@ -127,8 +130,8 @@
 
     - name: Read the results of the connection matrix test
       vars:
-        _my_vm_ip: "{{ host_name_to_vm_ip[ansible_host] }}"
-        _other_hostname: "{{ groups[node_group | d('node')] | map('extract', hostvars) | selectattr('ansible_host', 'equalto', other_vm.key) | map(attribute='inventory_hostname') | list | first}}"
+        _my_vm_ip: "{{ host_name_to_vm_ip[hostname_cmd] }}"
+        _other_hostname: "{{ groups[node_group | d('node')] | map('extract', hostvars) | selectattr('hostname_cmd', 'equalto', other_vm.key) | map(attribute='inventory_hostname') | list | first}}"
       ansible.builtin.slurp:
         src: "/tmp/conn-matrix-results/{{ inventory_hostname }}/{{ _other_hostname }}.json"
       loop: "{{ host_name_to_vm_ip | dict2items }}"
@@ -195,13 +198,13 @@
         path: "/tmp/conn-matrix-results/"
         state: absent
 
-    - name: Remove the IP address and route added to {{ conn_matrix_bridge_name }}
+    - name: Remove the IP address and route added to {{ _conn_matrix_bridge_name }}
       vars:
-        _my_vm_ip: "{{ host_name_to_vm_ip[ansible_host] }}"
+        _my_vm_ip: "{{ host_name_to_vm_ip[hostname_cmd] }}"
         _mapping_length: "{{ host_name_to_vm_ip | length }}"
       ansible.builtin.shell: |
-        ip addr del {{ _my_vm_ip | ansible.utils.ipmath(_mapping_length) }}/32 dev {{ conn_matrix_bridge_name }}
-        ip route del {{ _my_vm_ip }}/32 dev {{ conn_matrix_bridge_name }}
+        ip addr del {{ _my_vm_ip | ansible.utils.ipmath(_mapping_length) }}/32 dev {{ _conn_matrix_bridge_name }}
+        ip route del {{ _my_vm_ip }}/32 dev {{ _conn_matrix_bridge_name }}
       ignore_errors: true
 
 - hosts: "{{ frontend_group | d('frontend') }}"

--- a/playbooks/infra.yml
+++ b/playbooks/infra.yml
@@ -1,2 +1,0 @@
----
-- ansible.builtin.import_playbook: opennebula.deploy.infra

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -1,3 +1,0 @@
----
-- ansible.builtin.import_playbook: ./pre.yml
-- ansible.builtin.import_playbook: ./site.yml

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -1,2 +1,0 @@
----
-- ansible.builtin.import_playbook: opennebula.deploy.pre

--- a/playbooks/prepare-test-vm-template.yml
+++ b/playbooks/prepare-test-vm-template.yml
@@ -5,7 +5,7 @@
         block:
           - name: Download test VM template and image from the Marketplace
             ansible.builtin.shell: |
-              onemarketapp export $(onemarketapp list -f NAME='{{ test_vm_name }}' -l ID --no-header) -d $(onedatastore list -f TYPE=img -l ID --no-header | head -n 1) '{{test_vm_name}}'
+              onemarketapp export $(onemarketapp list -f NAME='{{ _test_vm_name }}' -l ID --no-header) -d $(onedatastore list -f TYPE=img -l ID --no-header | head -n 1) '{{_test_vm_name}}'
             register: vm_download
             # success when: rc == 0 or rc == 255 and 'NAME is already taken by IMAGE' in stderr
             failed_when: "vm_download.rc != 0 and (vm_download.rc != 255 or 'NAME is already taken by IMAGE' not in vm_download.stderr)"
@@ -20,7 +20,7 @@
 
           - name: Get existing VM template ID
             ansible.builtin.shell: >
-              onetemplate list --csv -f NAME='{{ test_vm_name }}' -l ID --no-header
+              onetemplate list --csv -f NAME='{{ _test_vm_name }}' -l ID --no-header
             register: existing_vm_template_id
             failed_when: "existing_vm_template_id.rc != 0"
             when: vm_download.rc == 255 and 'NAME is already taken by IMAGE' in vm_download.stderr

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,9 +1,0 @@
----
-- ansible.builtin.import_playbook: opennebula.deploy.site
-
-- hosts:
-    - "{{ frontend_group | d('frontend') }}"
-    - "{{ node_group | d('node') }}"
-  roles:
-    - { role: opennebula.deploy.helper.facts, _force: true }
-    - role: example

--- a/playbooks/tasks/conn_matrix_per_host.yml
+++ b/playbooks/tasks/conn_matrix_per_host.yml
@@ -33,7 +33,7 @@
 
 - name: "Host id: {{ host_id }} -- Instantiate test VM"
   ansible.builtin.command: |
-    onetemplate instantiate {{ test_vm_template_id }} --nic {{ conn_matrix_vnet_name }} \
+    onetemplate instantiate {{ test_vm_template_id }} --nic {{ _conn_matrix_vnet_name }} \
       --name conn-mtx-vm-on-host-{{ host_id }} --raw '{{
         (extra_template_content_raw.content | b64decode) +
         (test_vm_template_extra if test_vm_template_extra is defined else "")
@@ -46,7 +46,7 @@
   ansible.builtin.shell: >
     onevm list --f ID={{vm_id.stdout.split(':')[1] | trim}} -l STAT --no-header
   register: vm_state
-  failed_when: "vm_state.rc != 0"
+  failed_when: "vm_state.rc != 0 or 'runn' not in vm_state.stdout"
   until: vm_state.stdout == "runn"
   retries: 10
   delay: 10

--- a/playbooks/tasks/conn_matrix_per_host.yml
+++ b/playbooks/tasks/conn_matrix_per_host.yml
@@ -2,7 +2,7 @@
 - name: Set host_id and ssh_public_key for this iteration
   ansible.builtin.set_fact:
     host_id: "{{ item.split(',')[0] }}"
-    ssh_public_key: "{{ hostvars['localhost']['conn_matrix_pubkeys'][item.split(',')[1]] }}"
+    ssh_public_key: "{{ hostvars['localhost']['conn_matrix_pubkeys'][host_name_to_hostname_cmd[item.split(',')[1]]] }}"
 
 - name: "Host id: {{ host_id }} -- Render vm group template"
   template:

--- a/playbooks/vars/conn_matrix_defaults.yml
+++ b/playbooks/vars/conn_matrix_defaults.yml
@@ -1,7 +1,0 @@
----
-execute_conn_matrix: false
-conn_matrix_bridge_name: br0
-conn_matrix_ping_count: 10
-conn_matrix_vnet_name: vxlan
-# Also uses the 'test_vm_name' to define the Marketplace App name for test VM instantiation
-# and the 'test_vm_template_extra' variable to extend VM template if it is defined

--- a/playbooks/vars/test_vm_template_defaults.yml
+++ b/playbooks/vars/test_vm_template_defaults.yml
@@ -1,5 +1,0 @@
----
-# Marketplace App name for test VM instantiation
-test_vm_name: 'Alpine Linux 3.21'
-test_vm_template_extra: |
-  MEMORY="512"

--- a/playbooks/verification.yml
+++ b/playbooks/verification.yml
@@ -1,4 +1,21 @@
 ---
+- hosts: all
+  tasks:
+    - name: Set playbook variables for Connectivity Matrix
+      set_fact:
+        _conn_matrix_bridge_name: "{{ conn_matrix_bridge_name | d('br-default') }}"
+        _conn_matrix_ping_count: "{{ conn_matrix_ping_count | d(10) }}"
+        _conn_matrix_vnet_name: "{{ conn_matrix_vnet_name | d('vnet-default') }}"
+        # TODO: add a way to skip the whole conn_matrix if this is set to false. Right now it is always executed
+        execute_conn_matrix: false
+
+    - name: Set playbook variables for test VM
+      set_fact:
+        _test_vm_name: "{{ test_vm_name | d('Alpine Linux 3.21') }}"
+        # NOTE: Optional parameters, can be overridden in the inventory file
+        # test_vm_template_extra: |
+        #    MEMORY=256
+
 - ansible.builtin.import_playbook: ./prepare-test-vm-template.yml
 
 - hosts: "{{ frontend_group | d('frontend') }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,6 @@ skip-install = true
 installer = "uv"
 dependencies = [
   "ansible-core",
-  "jmespath"
+  "jmespath",
+  "netaddr"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.9"
 
-[tool.hatch.envs.default]
+[tool.hatch.envs.validation-default]
 skip-install = true
 installer = "uv"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,6 @@ requires-python = ">=3.9"
 skip-install = true
 installer = "uv"
 dependencies = [
-  "ansible-core<2.17",
+  "ansible-core",
   "jmespath"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "engineering-deploy"
+name = "one-deploy-validation"
 version = "0.0.0"
-description = "OpenNebula Engineering Ansible Playbooks"
+description = "OpenNebula Engineering Ansible Playbooks for Deployment Validation"
 authors = ["OpenNebula <contact@opennebula.io>"]
 license = "Apache-2.0"
 readme = "README.md"
@@ -12,20 +12,5 @@ skip-install = true
 installer = "uv"
 dependencies = [
   "ansible-core<2.17",
-  "ansible-lint",
-  "molecule",
-  "netaddr",
-  "pyone",
-  "jmespath",
-]
-
-[tool.hatch.envs.ceph]
-skip-install = true
-installer = "uv"
-dependencies = [
-  "ansible-core<2.16",
-  "molecule",
-  "netaddr",
-  "pyone",
-  "setuptools",
+  "jmespath"
 ]

--- a/roles/test_vm/defaults/main.yml
+++ b/roles/test_vm/defaults/main.yml
@@ -1,13 +1,7 @@
 ---
-#################### TEST EXECUTION CONTROL VARIABLES ####################
-run_core_services_verification: true
-
 #################### TEST CONFIGURATION VARIABLES ####################
 # Do we want check connection to the test VM? network might be blocked from FE
 test_vm_check_connection: false
-
-#
-execute_storage_benchmarking: false
 
 # Should we create a test network or reuse existing net? Existin network defined in {{test_vnet_name}} var
 create_test_network: false

--- a/roles/verification/defaults/main.yml
+++ b/roles/verification/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+#################### TEST EXECUTION CONTROL VARIABLES ####################
+run_core_services_verification: true
+verification_check_fireedge_ui: true

--- a/roles/verification/tasks/core_services_verification.yml
+++ b/roles/verification/tasks/core_services_verification.yml
@@ -167,47 +167,49 @@
   set_fact:
     verification_result: "{{ verification_result | combine({'Verify one-flow service port is open on the server' : 'ok'}) }}"
 
-- name: Verify fireedge GUI stops and starts
-  ansible.builtin.shell: |
-    systemctl stop opennebula-fireedge && systemctl start opennebula-fireedge
-    sleep 3
-    systemctl status opennebula-fireedge | grep Active | grep -o '(running)'
-  register: fireedge_status
-  failed_when: "'running' not in fireedge_status.stdout"
+- block:
+  - name: Verify fireedge GUI stops and starts
+    ansible.builtin.shell: |
+      systemctl stop opennebula-fireedge && systemctl start opennebula-fireedge
+      sleep 3
+      systemctl status opennebula-fireedge | grep Active | grep -o '(running)'
+    register: fireedge_status
+    failed_when: "'running' not in fireedge_status.stdout"
 
-- name: Verify fireedge GUI stops & starts
-  set_fact:
-    verification_result: "{{ verification_result | combine({'Verify fireedge GUI stops and starts' : 'ok'}) }}"
+  - name: Verify fireedge GUI stops & starts
+    set_fact:
+      verification_result: "{{ verification_result | combine({'Verify fireedge GUI stops and starts' : 'ok'}) }}"
 
-- name: Verify fireedge service is configured to start at boot time
-  ansible.builtin.shell: >
-    systemctl status opennebula-fireedge | grep enabled
-  register: fireedge_enabled
-  failed_when: "'enabled' not in fireedge_enabled.stdout"
+  - name: Verify fireedge service is configured to start at boot time
+    ansible.builtin.shell: >
+      systemctl status opennebula-fireedge | grep enabled
+    register: fireedge_enabled
+    failed_when: "'enabled' not in fireedge_enabled.stdout"
 
-- name: Verify fireedge GUI enabled
-  set_fact:
-    verification_result: "{{ verification_result | combine({'Verify fireedge GUI is enabled to start automatically' : 'ok'}) }}"
+  - name: Verify fireedge GUI enabled
+    set_fact:
+      verification_result: "{{ verification_result | combine({'Verify fireedge GUI is enabled to start automatically' : 'ok'}) }}"
 
-- name: Fireedge service listens on the server
-  ansible.builtin.shell: >
-    ss -tlpn | grep $(grep -A1 'FireEdge server port' /etc/one/fireedge-server.conf | grep port: | awk '{print $2}')
-  register: firedge_socket
-  failed_when: "firedge_socket.rc != 0"
+  - name: Fireedge service listens on the server
+    ansible.builtin.shell: >
+      ss -tlpn | grep $(grep -A1 'FireEdge server port' /etc/one/fireedge-server.conf | grep port: | awk '{print $2}')
+    register: firedge_socket
+    failed_when: "firedge_socket.rc != 0"
 
-- name: Verify fireedge GUI listens on the server
-  set_fact:
-    verification_result: "{{ verification_result | combine({'Verify fireedge GUI listens port' : 'ok'}) }}"
+  - name: Verify fireedge GUI listens on the server
+    set_fact:
+      verification_result: "{{ verification_result | combine({'Verify fireedge GUI listens port' : 'ok'}) }}"
 
-- name: Connect to a fireedge server
-  ansible.builtin.shell: >
-    curl "{{ firedge_socket.stdout.split()[3] }}"
-  register: connection_status
-  failed_when: "connection_status.rc != 0"
+  - name: Connect to a fireedge server
+    ansible.builtin.shell: >
+      curl "{{ firedge_socket.stdout.split()[3] }}"
+    register: connection_status
+    failed_when: "connection_status.rc != 0"
 
-- name: Verify connection to a fireedge server
-  set_fact:
-    verification_result: "{{ verification_result | combine({'Verify connection to a fireedge server' : 'ok'}) }}"
+  - name: Verify connection to a fireedge server
+    set_fact:
+      verification_result: "{{ verification_result | combine({'Verify connection to a fireedge server' : 'ok'}) }}"
+  when: verification_check_fireedge_ui
 
 - name: Get registered hosts
   ansible.builtin.shell: >
@@ -218,7 +220,7 @@
 - name: Get hosts list
   set_fact:
     hosts_list: "{{ onehost_list.stdout | from_json | json_query('HOST_POOL.HOST[*].{id: ID, hostname: NAME, state: STATE}') }}"
-  failed_when: "connection_status.rc != 0"
+  failed_when: "onehost_list.rc != 0"
 
 - name: Verify hosts list
   set_fact:


### PR DESCRIPTION
**Description**

Simplifying the Ansible playbooks, removing dependencies on external submodules, and improving the connection matrix logic. Key updates include the removal of the `ceph-ansible` submodule and related configurations, refactoring of Makefile targets, and enhancements to the connection matrix playbook for better hostname handling.

### Removal of `ceph-ansible` and related configurations:
* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L1-L4): Removed the `ceph-ansible` submodule configuration.
* [`ansible.cfg`](diffhunk://#diff-13210d77ac2772aae5c065289c79fa9fbe18245da49ce14d4db717ca599fdd1bL2-R2): Deleted all references to `ceph-ansible` plugins and libraries.
* [`inventory/group_vars/ceph.yml`](diffhunk://#diff-7dd28db18cd5c10ba0bf7da1591fc12e21fc2595913edd842f32c5744534a170L1-L5): Removed Ceph-specific variables.
* [`playbooks/ceph.yml`](diffhunk://#diff-d17bbb70d925afdd7e0b16ecb0fc7740f740c487b37677106fea9bdc1fe661e8L1-L2): Deleted the Ceph playbook.

### Refactoring of Makefile and environment setup:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L5-R5): Replaced `ENV_DEFAULT` and `ENV_CEPH` with `ENV_ONE_DEPLOY_VALIDATION` for validation tasks, and removed unused targets like `all`, `infra`, `pre`, and `site`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L5-R5) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L20-L72)

### Enhancements to the connection matrix playbook:
* [`playbooks/conn-matrix.yml`](diffhunk://#diff-1f3bd58eb30d28d897091242b1447362efd48ca8026979347b6fcb9f2432c3d2R20-R27): Improved logic by introducing a `hostname_cmd` fact to handle hostnames dynamically, updated IP and route management commands, and refined the connectivity testing process. [[1]](diffhunk://#diff-1f3bd58eb30d28d897091242b1447362efd48ca8026979347b6fcb9f2432c3d2R20-R27) [[2]](diffhunk://#diff-1f3bd58eb30d28d897091242b1447362efd48ca8026979347b6fcb9f2432c3d2L36-R40) [[3]](diffhunk://#diff-1f3bd58eb30d28d897091242b1447362efd48ca8026979347b6fcb9f2432c3d2L94-R123) [[4]](diffhunk://#diff-1f3bd58eb30d28d897091242b1447362efd48ca8026979347b6fcb9f2432c3d2L198-R233)

### Removal of unused or redundant playbooks and variables:
* `playbooks/main.yml`, `playbooks/pre.yml`, `playbooks/site.yml`, and `playbooks/infra.yml`: Removed unused playbooks and roles. [[1]](diffhunk://#diff-a1c46b5abaa8d653fae43932d00ba7e931885f15cf2316cd41f4b5216442d63aL1-L3) [[2]](diffhunk://#diff-6ecb50c227898d42bbe89d1e9ce967eebb6bf16aaab35e3ec0b9ff26e7bed68fL1-L2) [[3]](diffhunk://#diff-9ef1522e7c01e88443a57c815c126c7d2a66c237952e1e110448c400789ef755L1-L9) [[4]](diffhunk://#diff-349515f9d2ced008b51733a75be486b26f891ad60b752a71190ccea7e6769f21L1-L2)
* `playbooks/vars/conn_matrix_defaults.yml` and `playbooks/vars/test_vm_template_defaults.yml`: Deleted unused default variables for the connection matrix and test VM templates. [[1]](diffhunk://#diff-488d42cced2f9d7b190a951f68df442415c8fa4d5a239e9c3652d82e847f9964L1-L7) [[2]](diffhunk://#diff-594fb5c4827f51ec60b22b367883a5194b191da666cffa4ebee57c982aee54ecL1-L5)

### Addition of a new inventory file for local testing:
* [`inventory/local-test.yaml`](diffhunk://#diff-7d09ef3d816778e958089e0e60b4614114d27ed2ab6d7d0ab73869c733f9ccdaR1-R24): Added a new inventory file with predefined variables and host configurations for local testing.

Closes #15 and Closes #16 