### PR TITLE
B OpenNebula/engineering#406: Fixed one-deploy validation when only 1…

### DIFF
--- a/playbooks/validation.yml
+++ b/playbooks/validation.yml
@@ -40,21 +40,27 @@
           changed_when: false
           no_log: true
 
-        - name: Set fact with host to "hostname_cmd" mapping
+        - name: Extract HOST raw (may be mapping or list)
+          set_fact:
+            host_raw: "{{ (host_list_json.stdout | from_json).HOST_POOL.HOST | default([]) }}"
+
+        - name: Normalize HOST list (always a list)
+          set_fact:
+            host_list: "{{ [host_raw] if (host_raw is mapping) else (host_raw | default([])) }}"
+
+        - name: Set fact with host to 'hostname_cmd' mapping
           set_fact:
             host_name_to_hostname_cmd: >-
-                {{
-                  dict(
-                    (host_list_json.stdout | from_json).HOST_POOL.HOST
-                    | map(attribute='NAME')
-                    | zip(
-                        (host_list_json.stdout | from_json).HOST_POOL.HOST
-                        | map(attribute='TEMPLATE')
-                        | map(attribute='HOSTNAME')
-                      )
-                  )
-                }}
-
+              {{
+                dict(
+                  (host_list | map(attribute='NAME'))
+                  | zip(
+                      host_list
+                      | map(attribute='TEMPLATE')
+                      | map(attribute='HOSTNAME')
+                    )
+                )
+              }}
 
 - ansible.builtin.import_playbook: ./conn-matrix.yml
 


### PR DESCRIPTION
(https://forum.opennebula.io/t/one-deploy-validation-fails-with-1-host/14019)

Standardized the validation output so it works consistently whether the inventory has one or multiple KVM hosts.
[cloud_verification_report_1h_after_update.html](https://github.com/user-attachments/files/21935271/cloud_verification_report_1h_after_update.html)
[cloud_verification_report_2h_after_update.html](https://github.com/user-attachments/files/21935272/cloud_verification_report_2h_after_update.html)
[cloud_verification_report_2h_before_update.html](https://github.com/user-attachments/files/21935273/cloud_verification_report_2h_before_update.html)




