### PR TITLE
F #-: Added OneFlow validation

### DIFF
--- a/inventory/reference/group_vars/all.yml
+++ b/inventory/reference/group_vars/all.yml
@@ -38,7 +38,13 @@ validation:
         desc: OpenNebula Fireedge GUI
       # Add other services if more should be checked.
     check_fireedge_ui: true
-
+  # TEST CASE NAME: OneFlow Smoke Test (service/state/vms)
+  # DESCRIPTION: Creates and instantiates a temporary OneFlow service, checks its state and
+  # VM count, and reports the result. If the service does not reach RUNNING, the state is
+  # recorded as a comment in the HTML report.
+  # OUTPUT: OneFlow smoke test result and optional failure comment in /tmp/cloud_verification_report.html
+  run_one_flow: true
+ 
   # TEST CASE NAME: Storage Benchmark
   # DESCRIPTION: Instantiates a VM for running storage benchmark from it. The VM needs to
   # have public internet access to install dependencies. The VM's connected network can

--- a/playbooks/templates/appendix-cloud-report.j2
+++ b/playbooks/templates/appendix-cloud-report.j2
@@ -117,16 +117,20 @@
 			<font color="#ffffff"><font size="3" style="font-size: 12pt"><b>Comments</b></font></font></p>
 		</td>
 	</tr>
-         {% for k, v in verification_result.items() %}	
-	<tr valign="top">
+  	{% for k, v in (verification_result | default({})).items() %}
+	    {% set comment = ((verification_comments | default({})).get(k, '') | trim) %}
+		<tr valign="top">
 		<td width="300" height="21" style="background: transparent; border: 1.00pt solid #000000; padding: 0.07in"><p align="left" style="page-break-inside: auto; orphans: 0; widows: 0; border: none; padding: 0in; background: transparent; page-break-after: auto">
 			<b>{{ k }}</b></p>
 		</td>
 		<td width="90" style="background: transparent; border: 1.00pt solid #000000; padding: 0.07in"><p align="left" style="page-break-inside: auto; orphans: 0; widows: 0; border: none; padding: 0in; background: transparent; page-break-after: auto">
-			{{ v }}</p>
+		    {% if comment == '' %}
+  		    {{ v }}
+			{% endif %}
+			</p>
 		</td>
 		<td width="260" style="background: transparent; border: 1.00pt solid #000000; padding: 0.07in"><p align="left" style="page-break-inside: auto; orphans: 0; widows: 0; border: none; padding: 0in; background: transparent; page-break-after: auto">
-
+          	{{ comment }}
 			</p>
 		</td>
 	</tr>

--- a/playbooks/validation.yml
+++ b/playbooks/validation.yml
@@ -41,6 +41,20 @@
   roles:
     - role: validation
 
+# Will launch OneFlow Smoke test
+- hosts: "{{ frontend_group | d('frontend') }}"
+  tasks:
+    - block:
+        - name: Run OneFlow validation
+          import_role:
+            name: oneflow_validation
+      rescue:
+        - debug:
+            msg: "OneFlow role failed, continue with the rest"
+      always:
+        - debug:
+            msg: "Proceeding to the next role"
+
 # Run FE HA verification only when variable run_fe_ha is set to true
 - hosts: "{{ frontend_group | d('frontend') }}"
   roles:
@@ -53,6 +67,7 @@
   become: false
   vars:
     verification_result: "{{ hostvars[groups[frontend_group | d('frontend')][0]].verification_result | default({'No verification results were found': 'N/A'})}}"
+    verification_comments: "{{ hostvars[groups[frontend_group | d('frontend')][0]].verification_comments | default({}) }}"
     date: "{{ lookup('pipe', 'date +%Y-%m-%d\\ %H:%M:%S') }}"
     validation_vars: "{{ hostvars[groups[frontend_group | d('frontend')][0]].validation | default({}) }}"
   tasks:

--- a/roles/oneflow_validation/defaults/main.yml
+++ b/roles/oneflow_validation/defaults/main.yml
@@ -1,0 +1,2 @@
+validation:
+  run_one_flow: false

--- a/roles/oneflow_validation/tasks/main.yml
+++ b/roles/oneflow_validation/tasks/main.yml
@@ -1,0 +1,210 @@
+---
+- name: OneFlow | validation block
+  when: validation.run_one_flow | default(false) | bool
+  block:
+    - name: OneFlow | Init OneFlow IDs
+      set_fact:
+        flow_template_id: ""
+        flow_service_id: ""
+        flow_failed: false
+        flow_error_msg: ""
+
+    - name: Init report maps on localhost
+      set_fact:
+        verification_result: "{{ verification_result | default({}) }}"
+        verification_comments: "{{ verification_comments | default({}) }}"
+#
+    - name: OneFlow | Render temporary service template
+      ansible.builtin.copy:
+        dest: "/tmp/flow-smoke-tpl.json"
+        mode: "0644"
+        content: |
+          {
+            "name": "flow-smoke-svc",
+            "deployment": "straight",
+            "shutdown_action": "terminate-hard",
+            "roles": [
+              {
+                "name": "app",
+                "cardinality": 2,
+                "min_vms": 2,
+                "vm_template": {{ test_vm_template_id }}
+              }
+            ]
+          }
+
+    - name: OneFlow | Create service template
+      ansible.builtin.shell: oneflow-template create /tmp/flow-smoke-tpl.json
+      args: { executable: /bin/bash }
+      register: flow_tpl_create
+      changed_when: true
+      failed_when: false
+
+    - name: OneFlow | Resolve template ID (primary stdout + fallback by name)
+      ansible.builtin.shell: |
+        set -euo pipefail
+        id_from_create="$(echo "{{ flow_tpl_create.stdout | default('') }}" | sed -n 's/.*ID:\s*\([0-9]\+\).*/\1/p' | head -1)"
+        if [ -n "$id_from_create" ]; then
+          echo "$id_from_create"
+        else
+          oneflow-template list | awk '$2=="flow-smoke-svc"{print $1; exit}'
+        fi
+      args: { executable: /bin/bash }
+      register: flow_template_id_cmd
+      changed_when: false
+      failed_when: false
+
+    - name: OneFlow | Store template ID
+      set_fact:
+        flow_template_id: "{{ flow_template_id_cmd.stdout | trim | default('', true) }}"
+
+    - name: OneFlow | Instantiate the service
+      ansible.builtin.shell: oneflow-template instantiate {{ flow_template_id }}
+      args: { executable: /bin/bash }
+      register: flow_svc_instantiate
+      changed_when: true
+      failed_when: false
+      when: flow_template_id | length > 0
+
+    - name: OneFlow | Resolve service ID (from instantiate stdout, else list last by name)
+      ansible.builtin.shell: |
+        set -euo pipefail
+        id_from_inst="$(echo "{{ flow_svc_instantiate.stdout | default('') }}" | sed -n 's/.*ID:\s*\([0-9]\+\).*/\1/p' | head -1)"
+        if [ -n "$id_from_inst" ]; then
+          echo "$id_from_inst"
+        else
+          oneflow list | awk '$2=="flow-smoke-svc"{print $1}' | tail -1
+        fi
+      args: { executable: /bin/bash }
+      register: flow_service_id_cmd
+      changed_when: false
+      failed_when: false
+      when: flow_template_id | length > 0
+
+    - name: OneFlow | Store service ID
+      set_fact:
+        flow_service_id: "{{ flow_service_id_cmd.stdout | trim | default('', true) }}"
+
+    - name: OneFlow | Wait for service state RUNNING (non-fatal, robust)
+      ansible.builtin.shell: |
+        set -o pipefail
+        state="$(oneflow show {{ flow_service_id }} 2>/dev/null | awk '/SERVICE STATE/{print $4; exit}')"
+        echo "${state:-UNKNOWN}"
+      args: { executable: /bin/bash }
+      register: flow_state_chk
+      changed_when: false
+      retries: 10
+      delay: 10
+      until: (flow_state_chk.stdout | trim) == 'RUNNING'
+      failed_when: false
+      when:
+        - flow_service_id | default('') | trim | length > 0
+
+    - name: OneFlow | Capture OneFlow when state is not RUNNING
+      ansible.builtin.shell: |
+        oneflow show {{ flow_service_id }} | tail -20
+      args: { executable: /bin/bash }
+      register: flow_last_log
+      changed_when: false
+      failed_when: false
+      when:
+        - flow_service_id | default('') | trim | length > 0
+        - (flow_state_chk.stdout | default('UNKNOWN') | trim) != 'RUNNING'
+
+    - name: OneFlow | Mark as failed by state
+      set_fact:
+        flow_failed: true
+        flow_error_msg: >-
+          {{ (flow_last_log.stdout | default('state=' ~ (flow_state_chk.stdout | default('UNKNOWN'))))
+            | regex_replace('\n', ' | ')
+            | trim }}
+      when:
+        - (flow_state_chk.stdout | default('UNKNOWN') | trim) != 'RUNNING'
+
+    - name: OneFlow | Get VM count
+      ansible.builtin.shell: |
+        oneflow show {{ flow_service_id }} | awk '/ROLE app/{f=1} f && /CARDINALITY/{print $3; exit}'
+      args: { executable: /bin/bash }
+      register: flow_vm_count
+      changed_when: false
+      failed_when: false
+      when:
+        - flow_service_id | default('') | trim | length > 0
+
+  rescue:
+    - name: OneFlow | Mark as failed and capture error message
+      set_fact:
+        flow_failed: true
+        flow_error_msg: >-
+          {{ (ansible_failed_result.stderr
+              | default(ansible_failed_result.msg
+              | default(ansible_failed_result.stdout
+              | default('unknown error'))))
+              | regex_replace('\n', ' | ') | trim }}
+
+  always:
+    - name: Init report maps
+      set_fact:
+        verification_result: "{{ verification_result | default({}) }}"
+        verification_comments: "{{ verification_comments | default({}) }}"
+
+    - name: OneFlow | Prepare report fields
+      set_fact:
+        flow_service_id_rep: "{{ (flow_service_id | default('N/A', true)) | trim | default('N/A', true) }}"
+        flow_state_rep: "{{ (flow_state_chk.stdout | default('UNKNOWN', true)) | trim | default('UNKNOWN', true) }}"
+        flow_vm_qty_rep: "{{ (flow_vm_count.stdout | default('0', true)) | trim | default('0', true) }}"
+
+    - name: OneFlow | Store smoke test result + comment (on localhost)
+      set_fact:
+        verification_result: >-
+          {{ verification_result | combine({
+            'OneFlow smoke test (service/state/vms)':
+              'service=' ~ flow_service_id_rep ~
+              ', state=' ~ flow_state_rep ~
+              ', vms_qty=' ~ flow_vm_qty_rep
+          }) }}
+        verification_comments: >-
+          {{ verification_comments | combine({
+            'OneFlow smoke test (service/state/vms)':
+              ((flow_state_rep != 'RUNNING')
+                | ternary('service state=' ~ flow_state_rep, ''))
+          }) }}
+
+    - name: OneFlow | Cleanup service (detect state)
+      ansible.builtin.shell: |
+        oneflow show {{ flow_service_id }} | awk '/SERVICE STATE/{print $4; exit}'
+      args: { executable: /bin/bash }
+      register: flow_state_for_cleanup
+      changed_when: false
+      failed_when: false
+      when:
+        - flow_service_id is defined
+        - (flow_service_id | trim) is match('^[0-9]+$')
+
+    - name: OneFlow | Cleanup service (recover --delete for FAILED_*)
+      ansible.builtin.shell: |
+        oneflow recover --delete {{ flow_service_id }}
+      args: { executable: /bin/bash }
+      when:
+        - flow_service_id is defined
+        - (flow_service_id | trim) is match('^[0-9]+$')
+        - (flow_state_for_cleanup.stdout | default('') | lower) is search('failed')
+      ignore_errors: yes
+
+    - name: OneFlow | Cleanup service (normal delete)
+      ansible.builtin.shell: |
+        oneflow delete {{ flow_service_id }}
+      args: { executable: /bin/bash }
+      when:
+        - flow_service_id is defined
+        - (flow_service_id | trim) is match('^[0-9]+$')
+        - not ((flow_state_for_cleanup.stdout | default('') | lower) is search('failed'))
+      ignore_errors: yes
+
+    - name: OneFlow | Cleanup temporary template
+      ansible.builtin.shell: oneflow-template delete {{ flow_template_id }}
+      args: { executable: /bin/bash }
+      when:
+        - flow_template_id is defined
+        - (flow_template_id | trim) is match('^[0-9]+$')
+      ignore_errors: yes


### PR DESCRIPTION
- Add OneFlow validation (instantiates a simple 2-VM service, checks it status and cleans it up)
- Updated report generating task with using 3rd tab for error messages

Resolves https://github.com/OpenNebula/engineering/issues/441