### PR TITLE
F #787: semi airgap infrastructure validation

### DIFF
--- a/playbooks/templates/appendix-cloud-report.j2
+++ b/playbooks/templates/appendix-cloud-report.j2
@@ -450,11 +450,11 @@
         <td>
           <div class="cn">{{ network_name }}</div>
           {% set test_vm_ip = results.get('Test VM IP', 'N/A') %}
-          {% set gw_ping_raw = results.get('\nNetwork GW ping, packet received', results.get('Network GW ping, packet received')) %}
-          {% set ext_ping_raw = results.get('\nExternal Host ping: ', results.get('External Host ping: ', results.get('\nExternal Host ping::', results.get('External Host ping::')))) %}
+          {% set gw_ping_raw = results.get('Network GW ping', results.get('\nNetwork GW ping, packet received', results.get('Network GW ping, packet received'))) %}
+          {% set ext_ping_raw = results.get('External Host ping', results.get('\nExternal Host ping: ', results.get('External Host ping: ', results.get('\nExternal Host ping::', results.get('External Host ping::'))))) %}
           {% set gw_ping = (gw_ping_raw | from_json) if gw_ping_raw is string and (gw_ping_raw | trim | regex_search('^\\{')) else gw_ping_raw %}
           {% set ext_ping = (ext_ping_raw | from_json) if ext_ping_raw is string and (ext_ping_raw | trim | regex_search('^\\{')) else ext_ping_raw %}
-          {% set dns_result = results.get('\nExternal host DNS resolvation', results.get('External host DNS resolvation')) %}
+          {% set dns_result = results.get('External host DNS resolution', results.get('\nExternal host DNS resolvation', results.get('External host DNS resolvation'))) %}
           {{ render_record_table('Validation Summary', [
             {'label': 'Test VM IP', 'value': test_vm_ip, 'mono': true},
             {'label': 'Gateway Check', 'value': 'Available' if gw_ping is mapping else 'Not available'},

--- a/playbooks/templates/appendix-cloud-report.j2
+++ b/playbooks/templates/appendix-cloud-report.j2
@@ -270,7 +270,11 @@
                 </td>
                 <td width="90" style="background: transparent; border: 1.00pt solid #000000; padding: 0.07in"><p align="left" style="page-break-inside: auto; orphans: 0; widows: 0; border: none; padding: 0in; background: transparent; page-break-after: auto">
 			{% for test, value in v.items() %}
-                        <b>{{ test }}</b>: {{ value }}</p>
+		{% if value is mapping %}
+		<b>{{ test | trim }}</b>: {{ value.packets_received }}/{{ value.packets_transmitted }} packets received ({{ value.packet_loss_percent }}% loss), avg RTT {{ value.round_trip_ms_avg }}ms</p>
+		{% else %}
+                        <b>{{ test | trim }}</b>: {{ value | trim }}</p>
+		{% endif %}
                         {% endfor %}
                 </td>
                 <td width="260" style="background: transparent; border: 1.00pt solid #000000; padding: 0.07in"><p align="left" style="page-break-inside: auto; orphans: 0; widows: 0; border: none; padding: 0in; background: transparent; page-break-after: auto">

--- a/roles/network_validation/tasks/cluster_networks.yml
+++ b/roles/network_validation/tasks/cluster_networks.yml
@@ -58,8 +58,8 @@
     ssh -i ~oneadmin/.ssh/id_rsa -o StrictHostKeyChecking=no root@{{item.stdout}} hostname
   register: vm_ssh_result
   until: vm_ssh_result.rc == 0
-  retries: 10
-  delay: 10
+  retries: 30
+  delay: 20
   loop: "{{ vm_ip.results }}"
   run_once: true
 
@@ -77,14 +77,14 @@
 
 - name: Check GW reachability from VM
   ansible.builtin.shell: |
-    ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{item.stdout}} "ping -c 3 $(ip route show default | awk '/default/ {print $3}') | /usr/bin/jc --ping --pretty"
+    ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{item.stdout}} "ping -c 10 \$(ip route show default | awk '/default/ {print \$3}') | jc --ping --pretty"
   register: gw_reachability
   loop: "{{ vm_ip.results }}"
   run_once: true
 
 - name: Check DNS resolvation
   ansible.builtin.shell: |
-    ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{item.stdout}} "dig {{ validation.network.ext_host  }}   | /usr/bin/jc --dig -p | jq .[].answer.[].data"
+    ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{item.stdout}} "dig {{ validation.network.ext_host }} | jc --dig -p | jq '.[].answer[].data'"
   register: dns_reachability
   loop: "{{ vm_ip.results }}"
   run_once: true
@@ -118,7 +118,7 @@
   vars:
     _nv_prefix: "{{ (_one_clusters_multi | bool) | ternary(current_cluster.name ~ '/', '') }}"
   set_fact:
-    network_verification_results: "{{ (network_verification_results | default({})) | combine({(_nv_prefix ~ item.0): {'Test VM IP': item.1, '\nNetwork GW ping, packet received': item.2, '\nExternal Host ping: ': item.3, '\nExternal host DNS resolvation':item.4}}) }}"
+    network_verification_results: "{{ (network_verification_results | default({})) | combine({(_nv_prefix ~ item.0): {'Test VM IP': item.1, 'Network GW ping': item.2, 'External Host ping': item.3, 'External host DNS resolution': item.4}}) }}"
   loop: "{{ one_networks.stdout.splitlines() | zip(vm_ips_list, gw_reachability_list, ext_host_reachability_list, dns_reachability_list) | list }}"
 
 

--- a/roles/network_validation/tasks/main.yml
+++ b/roles/network_validation/tasks/main.yml
@@ -51,8 +51,8 @@
     ssh -i ~oneadmin/.ssh/id_rsa -o StrictHostKeyChecking=no root@{{item.stdout}} hostname
   register: vm_ssh_result
   until: vm_ssh_result.rc == 0
-  retries: 10
-  delay: 10
+  retries: 30
+  delay: 20
   loop: "{{ vm_ip.results }}"
   run_once: true
 
@@ -70,14 +70,14 @@
 
 - name: Check GW reachability from VM
   ansible.builtin.shell: |
-    ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{item.stdout}} ping -c 3 $(ip route show default | awk '/default/ {print $3}') | jc --ping --pretty
+    ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{item.stdout}} "ping -c 10 \$(ip route show default | awk '/default/ {print \$3}') | jc --ping --pretty"
   register: gw_reachability
   loop: "{{ vm_ip.results }}"
   run_once: true
 
 - name: Check DNS resolvation
   ansible.builtin.shell: |
-    ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{item.stdout}} dig {{ validation.network.ext_host  }}   | jc --dig -p | jq .[].answer.[].data
+    ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{item.stdout}} "dig {{ validation.network.ext_host }} | jc --dig -p | jq '.[].answer[].data'"
   register: dns_reachability
   loop: "{{ vm_ip.results }}"
   run_once: true
@@ -109,7 +109,7 @@
 
 - name: Save VM IPs for report
   set_fact:
-    network_verification_results: "{{ (network_verification_results | default({})) | combine({item.0: {'Test VM IP': item.1, '\nNetwork GW ping, packet received': item.2, '\nExternal Host ping: ': item.3, '\nExternal host DNS resolvation':item.4}}) }}"
+    network_verification_results: "{{ (network_verification_results | default({})) | combine({item.0: {'Test VM IP': item.1, 'Network GW ping': item.2, 'External Host ping': item.3, 'External host DNS resolution': item.4}}) }}"
   loop: "{{ one_networks.stdout.splitlines() | zip(vm_ips_list, gw_reachability_list, ext_host_reachability_list, dns_reachability_list) | list }}"
 
 

--- a/roles/storage-benchmark/tasks/storage_benchmark.yml
+++ b/roles/storage-benchmark/tasks/storage_benchmark.yml
@@ -42,15 +42,21 @@
       ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{ vm_ip.stdout }}
     register: ssh_conn_result
     until: ssh_conn_result.rc == 0
-    retries: 10
+    retries: 20
     delay: 10
 
-  - name: Run Storage benchmark suite
+  - name: Install fio on benchmark VM
     become: true
     become_user: oneadmin
     ansible.builtin.shell: |
       ssh -q -oStrictHostKeyChecking=no root@{{ vm_ip.stdout }} apk update > /dev/null
       ssh -q -oStrictHostKeyChecking=no root@{{ vm_ip.stdout }} apk add fio > /dev/null
+    when: not (validation.storage_benchmark.skip_fio_install | d(false))
+
+  - name: Run Storage benchmark suite
+    become: true
+    become_user: oneadmin
+    ansible.builtin.shell: |
       ssh -q -oStrictHostKeyChecking=no root@{{ vm_ip.stdout }} 'cat > /tmp/onebench.fio << "EOF"
       [global]
       time_based=1

--- a/roles/storage-benchmark/tasks/storage_benchmark.yml
+++ b/roles/storage-benchmark/tasks/storage_benchmark.yml
@@ -44,15 +44,22 @@
       ssh -i ~oneadmin/.ssh/id_rsa -q -oStrictHostKeyChecking=no root@{{ vm_ip.stdout }}
     register: ssh_conn_result
     until: ssh_conn_result.rc == 0
-    retries: 10
+    retries: 20
     delay: 20
 
-  - name: Run Storage benchmark suite
+  # Semi air-gapped deployments use an image with fio preinstalled.
+  - name: Install fio on benchmark VM
     become: true
     become_user: oneadmin
     ansible.builtin.shell: |
       ssh -q -oStrictHostKeyChecking=no root@{{ vm_ip.stdout }} apk update > /dev/null
       ssh -q -oStrictHostKeyChecking=no root@{{ vm_ip.stdout }} apk add fio > /dev/null
+    when: not (validation.storage_benchmark.skip_fio_install | d(false))
+
+  - name: Run Storage benchmark suite
+    become: true
+    become_user: oneadmin
+    ansible.builtin.shell: |
       ssh -q -oStrictHostKeyChecking=no root@{{ vm_ip.stdout }} 'cat > /tmp/onebench.fio << "EOF"
       [global]
       time_based=1

--- a/roles/test_vm/tasks/prepare.yml
+++ b/roles/test_vm/tasks/prepare.yml
@@ -8,9 +8,12 @@
     _export_name: "{{ _test_vm_name }}{{ current_cluster.name_suffix }}"
     _export_ds_id: "{{ current_cluster.image_ds_id }}"
 
+# Recorded only when the marketplace was actually used — in semi air-gapped
+# deployments the template pre-exists and the export is skipped.
 - name: Verify VM Download from Marketplace
   set_fact:
     verification_result: "{{ (verification_result | default({})) | combine({'Download a test VM template from the marketplace' ~ current_cluster.report_suffix : 'ok' }) }}"
+  when: (_export_cmd is not skipped) and _export_cmd.rc == 0
 
 - name: Write extra template variables to a temporary file on the remote host
   ansible.builtin.copy:

--- a/roles/test_vm/tasks/prepare.yml
+++ b/roles/test_vm/tasks/prepare.yml
@@ -1,34 +1,33 @@
 ---
+- name: Check if VM template already exists in OpenNebula
+  ansible.builtin.shell: >
+    onetemplate list --csv -f NAME='{{ _test_vm_name }}' -l ID --no-header
+  register: existing_vm_template_id
+  changed_when: false
+  failed_when: existing_vm_template_id.rc != 0
+
 - name: Download test VM template and image from the Marketplace
   ansible.builtin.shell: |
     onemarketapp export $(onemarketapp list -f NAME='{{ _test_vm_name }}' -l ID --no-header) -d $(onedatastore list -f TYPE=img -l ID --no-header | head -n 1) '{{_test_vm_name}}'
   register: vm_download
-  # success when: rc == 0 or rc == 255 and 'NAME is already taken by IMAGE' in stderr
-  failed_when: "vm_download.rc != 0 and (vm_download.rc != 255 or 'NAME is already taken by IMAGE' not in vm_download.stderr)"
+  failed_when: vm_download.rc != 0
+  when: existing_vm_template_id.stdout | trim == ''
 
 - name: Verify VM Download from Marketplace
   set_fact:
     verification_result: "{{ (verification_result | default({})) | combine({'Download a test VM template from the marketplace' : 'ok' }) }}"
+  when: vm_download is not skipped and vm_download.rc == 0
 
-# We have to check that image was downlodaded before attempting to instantiate VM
 - name: Get newly downloaded VM template ID
   ansible.builtin.shell: >
     echo '{{ vm_download.stdout }}' | grep -A1 VMTEMPLATE | grep ID | awk '{print $2}'
   register: new_vm_template_id
-  failed_when: "new_vm_template_id.rc != 0"
-  when: vm_download.rc == 0
-
-- name: Get existing VM template ID
-  ansible.builtin.shell: >
-    onetemplate list --csv -f NAME='{{ _test_vm_name }}' -l ID --no-header
-  register: existing_vm_template_id
-  failed_when: "existing_vm_template_id.rc != 0"
-  when: vm_download.rc == 255 and 'NAME is already taken by IMAGE' in vm_download.stderr
+  failed_when: new_vm_template_id.rc != 0
+  when: vm_download is not skipped and vm_download.rc == 0
 
 - name: Set VM template ID
   set_fact:
-    vm_template_id: "{{ new_vm_template_id if not new_vm_template_id.skipped|default(false) else existing_vm_template_id }}"
-  failed_when: new_vm_template_id.skipped|default(false) and existing_vm_template_id.skipped|default(false)
+    vm_template_id: "{{ new_vm_template_id if (vm_download is not skipped and vm_download.rc == 0) else existing_vm_template_id }}"
 
 - name: Write extra template variables to a temporary file on the remote host
   ansible.builtin.copy:

--- a/roles/validation_common/tasks/export_marketapp.yml
+++ b/roles/validation_common/tasks/export_marketapp.yml
@@ -15,6 +15,17 @@
     _export_template_id: ""
     _export_image_id: ""
 
+# Semi air-gapped deployments may have the template pre-registered without
+# any marketplace access: skip the export entirely when it already exists.
+- name: "Check if template '{{ _export_name }}' already exists"
+  ansible.builtin.shell: >
+    onetemplate list --csv -f NAME='{{ _export_name }}' -l ID --no-header
+  register: _export_precheck
+  failed_when: _export_precheck.rc != 0
+  changed_when: false
+  become: true
+  become_user: oneadmin
+
 - name: "Export '{{ _export_app_name }}' as '{{ _export_name }}' to datastore {{ _export_ds_id }}"
   ansible.builtin.shell: |
     onemarketapp export $(onemarketapp list -f NAME='{{ _export_app_name }}' -l ID --no-header) -d {{ _export_ds_id }} '{{ _export_name }}'
@@ -23,6 +34,7 @@
   become: true
   become_user: oneadmin
   changed_when: _export_cmd.rc == 0
+  when: _export_precheck.stdout | trim == ''
 
 - name: Get newly exported template ID
   ansible.builtin.shell: >
@@ -32,7 +44,7 @@
   changed_when: false
   become: true
   become_user: oneadmin
-  when: _export_cmd.rc == 0
+  when: (_export_cmd is not skipped) and _export_cmd.rc == 0
 
 - name: Get existing template ID
   ansible.builtin.shell: >
@@ -42,13 +54,14 @@
   changed_when: false
   become: true
   become_user: oneadmin
-  when: _export_cmd.rc == 255
+  when: (_export_cmd is not skipped) and _export_cmd.rc == 255
 
 - name: Set exported template ID
   ansible.builtin.set_fact:
     _export_template_id: >-
-      {{ (_export_new_id.stdout if not (_export_new_id.skipped | d(false))
-          else _export_existing_id.stdout) | trim }}
+      {{ (_export_precheck.stdout if (_export_precheck.stdout | trim != '')
+          else (_export_new_id.stdout if not (_export_new_id.skipped | d(false))
+          else _export_existing_id.stdout)) | trim }}
 
 # rc=255 only proves an IMAGE with this name exists; the matching template may
 # be missing or duplicated across owners, and the reused image may live in a


### PR DESCRIPTION
Fix network validation reliability, storage benchmark fio install options and test_vm idempotency:

1.  **roles/test_vm/tasks/prepare.yml**: 
- check for existing VM template before attempting marketplace download
- skip download when template already exists
- fix set_fact for vm_template_id to correctly select between new and existing IDs

2. **roles/storage_benchmark/tasks/storage_benchmark.yml**: 
- split fio installation into its own task and guard it with when: not (validation.storage_benchmark.skip_fio_install | d(false)) to allow skipping when the local built image already includes fio
- increase SSH readiness retries from 10 to 20 for slower VM boots

3. **roles/network_validation/tasksmain.yml**
- increase SSH readiness retries from 10×10s to 30×20s for slower VM boots
- fix shell quoting in GW ping command to prevent local $ variable expansion
- fix DNS check to use proper jq quoting
- increase ping count from 3 to 10 for GW and external host checks
- clean up result key names (remove leading \n, fix resolvation -> resolution)

4. **playbooks/templates/appendix-cloud-report.j2**:
- handle structured ping result objects in the report template: when a value is a mapping (ping result dict) render packets_received/packets_transmitted, packet loss %, and avg RTT instead of the raw dict
- fallback to plain string rendering for non-mapping values