### PR TITLE
B #503: One deploy validation patch

### DIFF
--- a/roles/validation/tasks/core_services_verification.yml
+++ b/roles/validation/tasks/core_services_verification.yml
@@ -116,7 +116,7 @@
 
 - name: Verify one-gate listen & port on the server
   ansible.builtin.shell: >
-    ss -tlpn | grep $(cat /etc/one/onegate-server.conf | awk '/^:port:/ {print $2}')
+    ss -tlpn | grep $(cat /etc/one/onegate-server.conf | awk '/:port:/ {print $2}')
   register: onegate_service
 
 - name: Save one-gate listen & port on the server

--- a/roles/validation_common/tasks/cluster_discovery.yml
+++ b/roles/validation_common/tasks/cluster_discovery.yml
@@ -160,13 +160,14 @@
   vars:
     _suffix: "{{ (one_clusters_multi | bool) | ternary('-' ~ item.name, '') }}"
     _test_vm_cfg: "{{ validation.test_vm | d({}) }}"
+    _run_test_vm: "{{ validation.run_test_vm | d(true) | bool }}"
     _test_vnet: "{{ _test_vm_cfg.vnet_name | d('VLAN_580') }}"
     _cm_vnet: "{{ (validation.conn_matrix | d({})).vnet_name | d('vnet-default') }}"
     _sb_vnet: "{{ (validation.storage_benchmark | d({})).vnet_name | d('VLAN_580') }}"
     _primary_vnet: >-
       {{ item.vnet_override if item.vnet_override
-         else ((_test_vnet ~ _suffix) if (_test_vm_cfg.create_vnet | d(true))
-         else (_test_vnet if _test_vnet in item.vnet_names_eligible
+         else ((_test_vnet ~ _suffix) if (_run_test_vm and (_test_vm_cfg.create_vnet | d(true)))
+         else (_test_vnet if (_run_test_vm and _test_vnet in item.vnet_names_eligible)
          else (item.vnet_names_eligible | first | d('')))) }}
     _extra:
       name_suffix: "{{ _suffix }}"


### PR DESCRIPTION
There are two separate fixes:
### 1. MAIN: [issue 503](https://github.com/OpenNebula/engineering/issues/503) 


test_vm test cases uses parameters from the test_vnet section, even when the run_test_vnet is disabled. This contradicts to the target guidelines to fully separate the testcases.

**The issue** was in cluster_discovery.yml at line 163:

`_test_vnet: "{{ _test_vm_cfg.vnet_name | d('VLAN_580') }}"
`
This reads `validation.test_vm.vnet_name` to resolve `_primary_vnet `(which becomes `current_cluster.vnet_name`). When `run_test_vm` is disabled, this still drives vnet selection for all other test cases.

`test_vm` should have its own `vnet_name` parameter independent of `test_vnet`. Looking at the `defaults/main.yml `— it already has `validation.test_vm.vnet_name`. The cross-dependency is in` cluster_discovery.yml` where `test_vnet `is used to seed `primary_vnet` for the whole cluster, which then feeds back into `create_vm.yml` and `connect.yml` via `current_cluster.vnet_name`.

**The fix:** in `cluster_discovery.yml`, only use `test_vm.vnet_name` for `_primary_vnet_ when _run_test_vm` is enabled. When disabled, fall back to the first eligible vnet directly.

Now the decision tree is as follows:
```

1. Is there a cluster_overrides.vnet_name for this cluster?
   YES → use it, stop.
   NO  ↓

2. Is run_test_vm enabled AND create_vnet: true?
   YES → use test_vm.vnet_name + cluster suffix (e.g. "public-myCluster"), stop.
         (the vnet doesn't exist yet; test_vm role will create it)
   NO  ↓

3. Is run_test_vm enabled AND test_vm.vnet_name exists in this cluster's eligible vnets?
   YES → use test_vm.vnet_name as-is, stop.
   NO  ↓

4. Fall back to the first eligible vnet discovered in the cluster.
```


In short: test VM either uses imposed vnet or creates own. At least that seems to be expected looking at the code.

### 2. SEPARATE ISSUE

opennebula-gate server test was failing due to wrong parsing parameters. Test was unable to get port configured and failed. It expected "port : 5030" from start of line, but in reality it's "  port : 5030" (two spaces).



**Fix:** removed ^ to ignore whitespace and catch "port" in line